### PR TITLE
Add workflow_dispatch trigger to Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '**'


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the Docker build workflow
- Allows manual triggering from the GitHub Actions UI via "Run workflow" button

## Test plan
- [ ] Verify the workflow can be manually triggered from Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)