### PR TITLE
Add Quay.io badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # py3-bio
 [![Build and Push Docker Image](https://github.com/broadinstitute/py3-bio/actions/workflows/docker-build.yml/badge.svg)](https://github.com/broadinstitute/py3-bio/actions/workflows/docker-build.yml)
+[![Docker Repository on Quay](https://quay.io/repository/broadinstitute/py3-bio/status "Docker Repository on Quay")](https://quay.io/repository/broadinstitute/py3-bio)
 
 This builds a docker container with just Python3 and commonly used bioinformatic Python packages, including biopython, pysam, dash/pandas/numpy/scipy, etc (see requirements.txt for full list).


### PR DESCRIPTION
## Summary
- Add badge linking to the Docker image repository on Quay.io

## Test plan
- [ ] Verify badge renders correctly in README
- [ ] Verify badge links to https://quay.io/repository/broadinstitute/py3-bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)