### PR TITLE
Switch Docker builds from OCI to Docker v2 manifests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,9 +77,11 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          outputs: type=image,push=${{ github.event_name == 'push' }},oci-mediatypes=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

- Disable provenance and SBOM attestations which force OCI manifest format
- Use `outputs` with `oci-mediatypes=false` to produce Docker v2 manifests instead of OCI
- Fixes Quay.io returning wrong (v1) manifests when tools like Cromwell request Docker v2 format

Proven approach from [viral-ngs PR #1047](https://github.com/broadinstitute/viral-ngs/pull/1047).

## Test plan

- [ ] GH Actions build completes successfully
- [ ] Build log shows Docker v2 media types in manifest push
- [ ] On Quay.io, `Accept: application/vnd.docker.distribution.manifest.list.v2+json` returns HTTP 200 with matching content-type

🤖 Generated with [Claude Code](https://claude.com/claude-code)