### PR TITLE
Fix scheduled Trivy scan and upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday scan for new CVEs
+    - cron: '0 12 * * *'  # Daily scan for new CVEs
   delete:
 
 permissions:
@@ -38,17 +38,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Login to custom registry
         if: github.event_name == 'push' && env.USE_CUSTOM_REGISTRY == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -69,14 +69,14 @@ jobs:
 
       - name: Login to GHCR
         if: github.event_name == 'push' && env.USE_CUSTOM_REGISTRY != 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -91,12 +91,15 @@ jobs:
   # Scan the pushed image for vulnerabilities
   scan:
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: |
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Login to custom registry
         if: env.USE_CUSTOM_REGISTRY == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -104,7 +107,7 @@ jobs:
 
       - name: Login to GHCR
         if: env.USE_CUSTOM_REGISTRY != 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,10 +126,11 @@ jobs:
         run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
 
       - name: Checkout (for ignore policy)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner (table)
-        uses: aquasecurity/trivy-action@master
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
           format: table
@@ -136,7 +140,8 @@ jobs:
           ignore-policy: .trivy-ignore-policy.rego
 
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@master
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         if: always()
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # py3-bio
 [![Build and Push Docker Image](https://github.com/broadinstitute/py3-bio/actions/workflows/docker-build.yml/badge.svg)](https://github.com/broadinstitute/py3-bio/actions/workflows/docker-build.yml)
-[![Docker Repository on Quay](https://quay.io/repository/broadinstitute/py3-bio/status "Docker Repository on Quay")](https://quay.io/repository/broadinstitute/py3-bio)
+[![Quay.io](https://img.shields.io/badge/quay.io-py3--bio-blue)](https://quay.io/repository/broadinstitute/py3-bio?tab=tags&tag=latest)
 
 This builds a docker container with just Python3 and commonly used bioinformatic Python packages, including biopython, pysam, dash/pandas/numpy/scipy, etc (see requirements.txt for full list).


### PR DESCRIPTION
## Summary

- Fixes the scheduled Trivy vulnerability scan that has never successfully run
- Upgrades all GitHub Actions to Node.js 24 to avoid upcoming deprecation
- Improves security by pinning trivy-action to a commit SHA
- Updates README badge for Quay.io repository

## Primary Bug Fix: Scheduled Scan Never Ran

The weekly Monday Trivy scan was configured but **never executed** because:
- The `scan` job declares `needs: build`
- The `build` job is skipped on `schedule` events (line 37)
- GitHub Actions skips jobs when their required dependencies are skipped

**Fix**: Modified the `scan` job's `if` condition to use `always()` with explicit build result checks. Now the scan runs when `build` succeeds (push events) OR when `build` is skipped (schedule events), but NOT when `build` fails.

Also changed the schedule from weekly Monday 6am UTC to **daily noon UTC** for more frequent CVE detection.

## GitHub Actions Node.js 24 Migration

Node.js 20 will be [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) with forced migration starting June 2, 2026. Upgraded all actions:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |
| github/codeql-action | v4 | v4 (already Node.js 24) |

## Trivy Action Security Hardening

Pinned `aquasecurity/trivy-action` to commit SHA `ed142fd` (v0.36.0) instead of `@master`. The trivy-action repository was [compromised in March 2026](https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/) with all version tags force-pushed to malicious commits. While tags were restored, SHA pinning prevents future tag manipulation attacks.

## README Update

Replaced the Quay build-status badge (which shows stale status from when Quay built containers) with a static shields.io badge linking to the Quay tags page. Builds are now done via GitHub Actions, not Quay.

## Test Plan

- [x] Workflow changes reviewed
- [ ] Push to this branch triggers build+scan successfully
- [ ] After merge, verify daily noon UTC cron runs the scan job
- [ ] README badges render correctly on GitHub
