### PR TITLE
Limit Trivy SARIF output to CRITICAL/HIGH severities

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -148,6 +148,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           ignore-policy: .trivy-ignore-policy.rego
 


### PR DESCRIPTION
## Summary
- The trivy-action ignores the `severity` input when `format: sarif` and emits all vulnerabilities by default — confirmed in the post-merge run for #12: `Building SARIF report with all severities`.
- That is why the GitHub Security tab is noisy with MEDIUM/LOW Trivy alerts even though the table scan and the build-failing gate are limited to `CRITICAL,HIGH`.
- Setting `limit-severities-for-sarif: true` makes the SARIF upload honor the existing `severity: CRITICAL,HIGH` filter. The table step was already correct and is unchanged.

## Test plan
- [ ] CI scan job runs on this branch and the SARIF step no longer logs `Building SARIF report with all severities`.
- [ ] After merge to main, no new MEDIUM/LOW Trivy alerts appear in the Security tab on subsequent scans (pre-existing alerts will clear once they are superseded by the next scan).
