### PR TITLE
Upgrade to Python 3.13 and patch CVE-2026-35414, CVE-2026-35386, CVE-2026-35385, CVE-2026-6100, CVE-2026-1299

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.12
+FROM python:3.13
 
 LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
+
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
## Summary
Fixes CVEs flagged by this morning's Trivy cron scan (run [25990711545](https://github.com/broadinstitute/py3-bio/actions/runs/25990711545)).

## Changes
- **Bump base image**: `FROM python:3.12` → `FROM python:3.13`
  - Forces fresh base pull (bypasses Docker layer cache)
  - Aligns container runtime with system Python (eliminates 3.12-on-3.13 mismatch)
- **Add OS security patches**: `RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*`
  - Ensures latest Debian security patches regardless of Docker Hub base freshness

## CVEs Addressed

| CVE | Severity | Package | Fixed Version |
|-----|----------|---------|---------------|
| CVE-2026-35414 | HIGH | openssh-client | 1:10.0p1-7+deb13u3 |
| CVE-2026-35386 | HIGH | openssh-client | 1:10.0p1-7+deb13u3 |
| CVE-2026-35385 | HIGH | openssh-client | 1:10.0p1-7+deb13u3 |
| CVE-2026-6100 | HIGH (9.1) | python3.13 (4 packages) | 3.13.5-2+deb13u2 |
| CVE-2026-1299 | HIGH | python3.13 (4 packages) | 3.13.5-2+deb13u1 |

## Exploitability Assessment
Real-world risk in this batch bioinformatics container is low:
- OpenSSH CVEs: Container is client-only (no sshd), runs non-root, pipeline-controlled SSH params
- Python CVEs: Require edge cases (memory pressure + decompressor reuse, or email generation)

## Test Plan
- [ ] CI build job completes successfully with new base image
- [ ] CI scan job passes (no CRITICAL/HIGH findings)
- [ ] Security tab alerts auto-close
