### PR TITLE
Add force_rebuild dispatch input; shift daily scan to 09:00 UTC

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,11 @@ name: Build and Push Docker Image
 
 on:
   workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: 'Bypass GHA layer cache (use after a scheduled Trivy alert to absorb fresh apt patches)'
+        type: boolean
+        default: false
   push:
     branches:
       - '**'
@@ -10,7 +15,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 12 * * *'  # Daily scan for new CVEs
+    - cron: '0 9 * * *'  # Daily scan for new CVEs
   delete:
 
 permissions:
@@ -87,6 +92,7 @@ jobs:
           outputs: type=image,push=${{ github.event_name == 'push' }},oci-mediatypes=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: ${{ inputs.force_rebuild || false }}
 
   # Scan the pushed image for vulnerabilities
   scan:


### PR DESCRIPTION
## Summary

- Add `force_rebuild` boolean input to `workflow_dispatch` that pipes through to `no-cache` on the build step. Default `false` keeps push/PR builds fast and cached.
- Shift the daily scheduled scan from 12:00 UTC → 09:00 UTC.

## Why

The 2026-05-20 scheduled Trivy scan surfaced 16 open security alerts — all reducing to one root cause: 4 GnuTLS CVEs (CVE-2026-42010, CVE-2026-33845 critical; CVE-2026-42011, CVE-2026-3833 high) across 4 packages, all fixed in `libgnutls30t64 3.8.9-3+deb13u4`. The image hasn't been rebuilt since 2026-05-17 (PR #14), so the `apt-get upgrade` baked into the Dockerfile pre-dates Debian's `+deb13u4` security update.

The scheduled scan is doing exactly what it should: lightweight drift detection between the last human-triggered build and current CVE state. The gap is that the obvious human response — re-run the workflow via `workflow_dispatch` — was effectively a no-op: `docker/build-push-action@v7` with `cache-from/to: type=gha` will reuse the cached `RUN apt-get update && upgrade` layer (its cache key has no inputs that change run-to-run), so re-triggering produced an identical image and the same alerts.

After this change, the human response when a scheduled scan flags drift is one click: Actions → Run workflow → check **force_rebuild** → Run. That run bypasses the GHA layer cache, `apt-get upgrade` re-executes against the current Debian archive, and the fresh image is pushed to `:latest`.

## Test plan

- [ ] Merge this PR; confirm the merge `push` build runs successfully on the cached path (~1-2min build).
- [ ] On `main`, trigger Actions → "Build and Push Docker Image" → Run workflow → check **force_rebuild** → Run. Expect a ~15-25min from-scratch build that pushes a fresh `:latest`.
- [ ] After the next scheduled scan (09:00 UTC the following day), confirm the 16 GnuTLS alerts in the Security tab close out automatically: `gh api repos/broadinstitute/py3-bio/code-scanning/alerts -q '.[] | select(.state=="open") | .number'` should return empty (or significantly shorter).
- [ ] After two days, confirm `gh run list --workflow=docker-build.yml --event=schedule -L 3` shows scheduled runs at the new 09:00 UTC time.