### PR TITLE
Fix scan job failing on tag pushes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -125,7 +125,7 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Pull image


### PR DESCRIPTION
## Summary
- The scan job's tag-determination step only stripped refs/heads/ from GITHUB_REF, so tag pushes produced refs/tags/0.1.6 as the Docker tag — slashes are invalid in Docker tags, causing immediate failure
- Replaced ${GITHUB_REF#refs/heads/} with ${{ github.ref_name }}, which gives the bare name for both branches and tags
- This is what broke the 0.1.6 tag push (run 26289270893)

## Test plan
- [ ] Merge and tag a new release (e.g. 0.1.7) to confirm the scan job passes
- [ ] Verify the next scheduled daily run on main still uses latest correctly