### PR TITLE
Enable scan job for workflow_dispatch events

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -99,7 +99,7 @@ jobs:
     needs: build
     if: |
       always() &&
-      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Allow workflow_dispatch to trigger the scan job in addition to push and schedule events.

## Motivation

When using the force_rebuild dispatch input to absorb fresh apt patches after a Trivy alert, the scan job was skipped because the condition only allowed push or schedule events. This meant CVE fixes could not be immediately validated.

## Changes

- Updated the scan job condition to include github.event_name == 'workflow_dispatch'

## Testing

After merging, manual workflow dispatches (including force_rebuild runs) will execute the full build+scan cycle and report results to the GitHub Security tab.