### PR TITLE
Upgrade OpenSSL packages to patch CVE-2026-45447

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
## Summary

Adds targeted `apt-get upgrade` for OpenSSL-related packages to address CVE-2026-45447 (HIGH severity use-after-free in `PKCS7_verify()`).

The upstream `python:3.13` base image has not yet been updated to include the fixed Debian packages (`3.5.6-1~deb13u2`), so we explicitly upgrade the four affected packages:
- `openssl`
- `libssl-dev`
- `libssl3t64`
- `openssl-provider-legacy`

## Context

This morning's scheduled Trivy scan (run 27269890363) found CVE-2026-45447 in all four OpenSSL packages. I initially tried a force rebuild (`force_rebuild=true`) to bypass the Docker layer cache, but the CVE persisted because the upstream Python base image hasn't absorbed the Debian security update yet.

## Precedent

This follows the same pattern as viral-ngs PR #1090, which added targeted package upgrades for the same CVE.

## Verification

The CI Trivy scan must pass before merge.