### PR TITLE
Upgrade libssh2 packages to patch CVE-2026-55200 and CVE-2026-7598

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
## Summary

- Adds `libssh2-1t64` and `libssh2-1-dev` to the targeted `apt-get upgrade` list in the Dockerfile to absorb the `1.11.1-1+deb13u1` Debian security patches
- Fixes two HIGH-severity CVEs surfaced by the daily Trivy scan on 2026-06-26 (run #28231334781)
- No Python dependency changes; libssh2 is a transitive OS-level dependency of the base image SSH tooling

## CVEs addressed

| CVE | Severity | Issue |
|-----|----------|-------|
| CVE-2026-55200 | HIGH | Out-of-bounds write via unchecked length in libssh2 |
| CVE-2026-7598 | HIGH | Integer overflow via large username or password |

Both are fixed in Debian 13 package `1.11.1-1+deb13u1`. The `ignore-unfixed: true` scan flag does not suppress them because a fix is available, and the `.trivy-ignore-policy.rego` correctly does not ignore them (memory-corruption bugs, not availability-only or local-only).

## Why now

The OpenSSL CVE fix in #18 (`94df0cc`) switched from a blanket `apt-get upgrade -y` to a targeted list covering only OpenSSL packages. libssh2 was not on that list, so new Debian advisories for it now surface in the daily scan until explicitly added.

## Test plan

- [ ] Verify the `scan` job passes on this PR's push CI run (Trivy exit-code-1 passes only if zero HIGH/CRITICAL unfixed findings remain)
- [ ] After merge, trigger **Build and Push Docker Image** via `workflow_dispatch` with **`force_rebuild: true`** to bust the GHA layer cache and ensure the live `latest` tag picks up the patched packages
- [ ] Confirm the daily scan passes the following morning
