### PR TITLE
Upgrade ImageMagick packages to patch CVE-2026-56367 and CVE-2026-56378

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 imagemagick imagemagick-7-common imagemagick-7.q16 libmagickcore-7-arch-config libmagickcore-7-headers libmagickcore-7.q16-10 libmagickcore-7.q16-10-extra libmagickcore-7.q16-dev libmagickcore-dev libmagickwand-7-headers libmagickwand-7.q16-10 libmagickwand-7.q16-dev libmagickwand-dev && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
## Summary
- The daily scheduled Trivy scan (run [28933436763](https://github.com/broadinstitute/py3-bio/actions/runs/28933436763)) failed on 2026-07-08 with 26 CRITICAL/HIGH findings, all reducing to two CVEs in the ImageMagick family shipped by the `python:3.13` base image: **CVE-2026-56367** (CRITICAL) and **CVE-2026-56378** (HIGH, denial of service / information disclosure).
- Installed version `8:7.1.1.43+dfsg1-1+deb13u10` is fixed in Debian trixie's `...+deb13u11`, but the upstream base image hasn't picked it up yet.
- Adds the imagemagick/libmagickcore/libmagickwand packages to the existing targeted `apt-get upgrade` list in the Dockerfile, following the same pattern used for the prior openssl (#18) and libssh2 (#19) CVE fixes.

## Test plan
- [x] `git diff` reviewed — single-line Dockerfile change appending 13 package names to the existing upgrade list
- [ ] CI `scan` job on this PR passes (rebuilds the image and re-runs Trivy against it — green scan confirms the CVEs are patched)
- [ ] After merge, confirm the next scheduled Trivy scan on `main` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)