### PR TITLE
Upgrade curl packages to patch CVE-2026-5773

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 imagemagick imagemagick-7-common imagemagick-7.q16 libmagickcore-7-arch-config libmagickcore-7-headers libmagickcore-7.q16-10 libmagickcore-7.q16-10-extra libmagickcore-7.q16-dev libmagickcore-dev libmagickwand-7-headers libmagickwand-7.q16-10 libmagickwand-7.q16-dev libmagickwand-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 imagemagick imagemagick-7-common imagemagick-7.q16 libmagickcore-7-arch-config libmagickcore-7-headers libmagickcore-7.q16-10 libmagickcore-7.q16-10-extra libmagickcore-7.q16-dev libmagickcore-dev libmagickwand-7-headers libmagickwand-7.q16-10 libmagickwand-7.q16-dev libmagickwand-dev curl libcurl3t64-gnutls libcurl4-openssl-dev libcurl4t64 && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
Patches HIGH CVE-2026-5773 (libcurl: wrong file transfer due to incorrect SMB connection reuse). Bumps the curl package family from `8.14.1-2+deb13u3` to `8.14.1-2+deb13u4`.

Clears the daily Trivy scan failure first observed on 2026-07-12. Follows the same pattern as #18/#19/#20 (append the affected package names to the Dockerfile `apt-get upgrade` line).

Affected packages:
- curl
- libcurl3t64-gnutls
- libcurl4-openssl-dev
- libcurl4t64

## Test plan
- [ ] Branch push triggers build + Trivy scan in CI — confirm the scan job passes (no CVE-2026-5773 in results)
- [ ] After merge, verify next scheduled daily scan (09:00 UTC) is green