### PR TITLE
Upgrade linux-libc-dev to patch CVE-2026-64600

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 
 WORKDIR /
 
-RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 imagemagick imagemagick-7-common imagemagick-7.q16 libmagickcore-7-arch-config libmagickcore-7-headers libmagickcore-7.q16-10 libmagickcore-7.q16-10-extra libmagickcore-7.q16-dev libmagickcore-dev libmagickwand-7-headers libmagickwand-7.q16-10 libmagickwand-7.q16-dev libmagickwand-dev curl libcurl3t64-gnutls libcurl4-openssl-dev libcurl4t64 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y openssl libssl-dev libssl3t64 openssl-provider-legacy libssh2-1-dev libssh2-1t64 imagemagick imagemagick-7-common imagemagick-7.q16 libmagickcore-7-arch-config libmagickcore-7-headers libmagickcore-7.q16-10 libmagickcore-7.q16-10-extra libmagickcore-7.q16-dev libmagickcore-dev libmagickwand-7-headers libmagickwand-7.q16-10 libmagickwand-7.q16-dev libmagickwand-dev curl libcurl3t64-gnutls libcurl4-openssl-dev libcurl4t64 linux-libc-dev && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /
 


### PR DESCRIPTION
Patches HIGH CVE-2026-64600 detected by the 2026-07-23 daily Trivy scan. Adds linux-libc-dev to the targeted Debian package upgrade list so the image uses the fixed 6.12.96-1 release instead of 6.12.95-1.

The advisory concerns XFS kernel code and linux-libc-dev provides userspace headers, so practical container exposure is low. Since Debian already provides a fixed package, upgrading is preferable to adding an ignore-policy exception.

References:
- Failed daily scan: https://github.com/broadinstitute/py3-bio/actions/runs/29996794714
- Code-scanning alert: https://github.com/broadinstitute/py3-bio/security/code-scanning/75
- Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-64600

## Test plan
- [x] Branch push built and pushed the amd64/arm64 image
- [x] Trivy table scan passed with no blocking HIGH/CRITICAL findings
- [x] Trivy SARIF scan and Security tab upload passed
- [x] Successful branch run: https://github.com/broadinstitute/py3-bio/actions/runs/30000926455
- [ ] After merge, verify the main push scan passes and alert #75 closes